### PR TITLE
Allinged the quantum gate div and fixed margin of other elements issue#7fixed. closes[#7]

### DIFF
--- a/qubitverse/visualizer/src/components/QuantumCircuit.jsx
+++ b/qubitverse/visualizer/src/components/QuantumCircuit.jsx
@@ -937,17 +937,14 @@ const QuantumCircuit = ({ numQubits, setNumQubits }) => {
                 {/* Left Menu: single box with gates on top and 3 buttons below */}
                 <div
                     style={{
-                        position: "fixed",
-                        top: "50%",
-                        left: "10px",
-                        width: "200px",
+                        float:"left",
+                        width: "17%",
                         border: "3px solid black",
                         borderRadius: "5px",
                         background: "white",
                         padding: "10px",
-                        marginTop: "60px",
                         zIndex: 10, // keep above the stage
-                        transform: "translateY(-50%)",
+
                     }}
                 >
                     <h2 className="text-l font-bold text-gray-800" style={{ userSelect: "none", textAlign: "center" }}>Quantum Gates</h2>
@@ -957,6 +954,7 @@ const QuantumCircuit = ({ numQubits, setNumQubits }) => {
                             border: "1px solid black",
                             borderRadius: "5px",
                             width: "100%",
+                            height:"250px",
                             padding: "5px",
                             display: "flex",
                             flexWrap: "wrap",
@@ -964,6 +962,7 @@ const QuantumCircuit = ({ numQubits, setNumQubits }) => {
                             justifyContent: "space-evenly",
                             marginBottom: "10px",
                             overflowY: "auto",
+                            scrollbarWidth:"none"
                         }}
                     >
                         {gatesList.map((gate, index) => {
@@ -1040,9 +1039,10 @@ const QuantumCircuit = ({ numQubits, setNumQubits }) => {
                 {/* Right Content: depends on active tab */}
                 <div
                     style={{
-                        marginLeft: "220px", // leave space for the left menu
-                        flex: 1,
+                        width:"80%",
+                        flex:1,
                         position: "relative",
+                        float:"right"
                     }}
                 >
                     {/* TOOLTIP */}


### PR DESCRIPTION
Issue Description:

- Misalligned Quantum gates div.
- The div of quantum gates is going through the Navbar.
- Its stopping the visibilty of I,X,Y,Z ,H and S gates.

Pull request update:-

- alligned the quantum gate div to the left.
- fixed the margin problem of other div .
- made the quantum gates div scrollable to introduce the buttons and functions below to the user.when page is loaded.
<img width="960" height="540" alt="qubitversr issue#7" src="https://github.com/user-attachments/assets/b705243f-4008-416c-8cec-23f9e2123628" />

Outcome:-
Closes #7 
- All the code is proper and site is running properly with no errors.

Next Steps:-

- Code review
- @Dark-CodeX  kindly review the code ,merge and close issue[#7] or provide new instructions.

